### PR TITLE
Stop requirement for default name argument

### DIFF
--- a/spec/artist_spec.rb
+++ b/spec/artist_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "Artist" do 
   it "has a name" do
-    artist = Artist.new
+    artist = Artist.new(nil)
     artist.name = "Beyonce" 
     expect(artist.name).to eq("Beyonce")
   end


### PR DESCRIPTION
Old test requires name to default to something because the test doesn't pass any args. So artist is passed nil.